### PR TITLE
Fix working directory resolution error

### DIFF
--- a/src/bin/clu.rs
+++ b/src/bin/clu.rs
@@ -276,7 +276,7 @@ pub async fn run_migration(args: RunMigrationArgs) -> AnyResult<()> {
     for (pretty_name, target) in &migration_input.targets {
         tasks.push((
             result_map.clone(),
-            prepair_migration(
+            prepare_migration(
                 &migration_input.definition,
                 &github_client,
                 &args.dry_run_opts,
@@ -350,7 +350,7 @@ pub async fn run_migration(args: RunMigrationArgs) -> AnyResult<()> {
 }
 
 #[allow(clippy::needless_lifetimes)]
-async fn prepair_migration<'a>(
+async fn prepare_migration<'a>(
     definition: &MigrationDefinition,
     github_client: &'a GithubApiClient,
     dry_run_opts: &DryRunOpts,
@@ -359,7 +359,7 @@ async fn prepair_migration<'a>(
     target: &TargetDescription,
 ) -> anyhow::Result<MigrationTask<'a>> {
     debug!("Processing {:?}", &pretty_name);
-    let target_dir = PathBuf::from(&work_directory_root).join(&pretty_name);
+    let work_dir = PathBuf::from(&work_directory_root);
 
     let env = match &target.env {
         Some(value) => value.clone(),
@@ -370,7 +370,7 @@ async fn prepair_migration<'a>(
         skip_pull_request: dry_run_opts.skip_pull_request,
         skip_push: dry_run_opts.skip_push,
         dry_run: dry_run_opts.dry_run,
-        work_dir: target_dir,
+        work_dir,
         env,
         github_client,
     };

--- a/src/commands/followup.rs
+++ b/src/commands/followup.rs
@@ -42,7 +42,7 @@ pub async fn run_followup(args: RunFollowupArgs) -> AnyResult<()> {
     let mut work_queue = Vec::new();
 
     for (name, target) in results.targets {
-        let target_dir = PathBuf::from(&args.work_directory_root).join(&name);
+        let target_dir = PathBuf::from(&args.work_directory_root);
 
         let pull = match target.pull_request {
             Some(pull) => pull,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -30,17 +30,18 @@ pub struct Workspace {
 
 impl Workspace {
     pub fn new_clean_workspace<S: Into<String>>(
-        workspace_name: S,
-        workspace_dir: &Path,
+        repo_workspace_name: S,
+        root_workspace_dir: &Path,
     ) -> Result<Self, std::io::Error> {
-        let workspace_name = workspace_name.into();
-        debug!("Processing {:?}", workspace_name);
-        if workspace_dir.exists() {
-            remove_dir_all(&workspace_dir)?
+        let repo_workspace_name = repo_workspace_name.into();
+        let repo_workspace_dir = PathBuf::from(&root_workspace_dir).join(&repo_workspace_name);
+        debug!("Processing {:?}", repo_workspace_name);
+        if repo_workspace_dir.exists() {
+            remove_dir_all(&repo_workspace_dir)?
         }
-        create_dir_all(&workspace_dir)?;
+        create_dir_all(&repo_workspace_dir)?;
 
-        Self::new(workspace_name, workspace_dir)
+        Self::new(repo_workspace_name, &repo_workspace_dir)
     }
 
     pub fn new<S: Into<String>>(


### PR DESCRIPTION
Fixes bug where the `work_dir` could not be found

When trying to run a migration from a clean state, the [code to get the canonical path for the work directory](https://github.com/ethankhall/clu/blob/fcee4d1d6c4aad4b34030af88e094c8e0ed8d9c2/src/migration.rs#L113) would fail with:
```
ERROR Unable to canonicalize dir: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

This was because the `work_dir` included the `pretty_name` of the repo. This directory doesn't exist yet, since it will be created by the `new_clean_workspace` function in a later step.

Because of this change, I also had to update `new_clean_workspace` slightly to make sure we are performing the work on the individual repo directories within the work directory, rather than the root `work_dir`.